### PR TITLE
Create share class with name attribute.

### DIFF
--- a/app/admin/share.rb
+++ b/app/admin/share.rb
@@ -1,0 +1,4 @@
+ActiveAdmin.register Share do
+  menu priority: 2
+  permit_params :name
+end

--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -1,0 +1,3 @@
+class Share < ActiveRecord::Base
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20170606185449_create_shares.rb
+++ b/db/migrate/20170606185449_create_shares.rb
@@ -1,0 +1,8 @@
+class CreateShares < ActiveRecord::Migration[5.0]
+  def change
+    create_table :shares do |t|
+      t.string :name
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170606182931) do
+ActiveRecord::Schema.define(version: 20170606185449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,12 @@ ActiveRecord::Schema.define(version: 20170606182931) do
     t.datetime "updated_at",                          null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true, using: :btree
+  end
+
+  create_table "shares", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,3 +3,7 @@ AdminUser.create!(
   password: 'password',
   password_confirmation: 'password'
 )
+
+Share.create!(name: "Vegetable")
+Share.create!(name: "Fruit")
+Share.create!(name: "Eggs")

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Share, type: :model do
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name) }
+end


### PR DESCRIPTION
## Why? 
- To create shares

## What Changed? 
- Created Share class with name attribute
- Validate presence and uniqueness of name attribute
- Added to admin interface so admins can create, edit, delete
- Add to seeds