### PR TITLE
Add size as enum to share class.

### DIFF
--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -1,3 +1,5 @@
 class Share < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
+
+  enum size: %i(full half)
 end

--- a/db/migrate/20170606192013_add_size_to_shares.rb
+++ b/db/migrate/20170606192013_add_size_to_shares.rb
@@ -1,0 +1,5 @@
+class AddSizeToShares < ActiveRecord::Migration[5.0]
+  def change
+    add_column :shares, :size, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170606185449) do
+ActiveRecord::Schema.define(version: 20170606192013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20170606185449) do
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "size"
   end
 
 end

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -3,4 +3,6 @@ require 'rails_helper'
 RSpec.describe Share, type: :model do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
+
+  it { is_expected.to define_enum_for(:size).with(%i(full half)) }
 end


### PR DESCRIPTION
## Why? 
- To allow user to choose share size

## What Changed? 
- Added size attribute to share
- Size is enum with two options: full and half